### PR TITLE
Document advanced globbing syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ nodemon --watch app --watch libs app/server.js
 
 Now nodemon will only restart if there are changes in the `./app` or `./libs` directory. By default nodemon will traverse sub-directories, so there's no need in explicitly including sub-directories.
 
-Nodemon also supports unix globbing, e.g `--watch './lib/*'`. The globbing pattern must be quoted.
+Nodemon also supports unix globbing, e.g `--watch './lib/*'`. The globbing pattern must be quoted. For advanced globbing, [see `picomatch` documentation](https://github.com/micromatch/picomatch#advanced-globbing), the library that nodemon uses through `chokidar` (which in turn uses it through `anymatch`).
 
 ## Specifying extension watch list
 


### PR DESCRIPTION
When figuring this out it enabled me to ignore everything in `node_modules` but my own `@yikesable/` scoped modules:

```json
  "ignoreRoot": [
    "**/node_modules/!(@yikesable)*",
    "**/node_modules/**/node_modules"
  ],
```

Especially handy when working with `npm link` and modifying ones scoped modules as part of ones main application.